### PR TITLE
#123 Load marimba and arm setup separately in Gazebo

### DIFF
--- a/marimbabot_description/launch/load_robot_description.launch
+++ b/marimbabot_description/launch/load_robot_description.launch
@@ -11,4 +11,6 @@
   <param name="robot_description" command="$(find xacro)/xacro '$(find marimbabot_description)/urdf/marimbabot_ur5.urdf.xacro'
     joint_ranges_config:=$(arg joint_ranges_config)
     transmission_hw_interface:=$(arg transmission_hw_interface)" />
+  
+  <param name="marimba_description" command="$(find xacro)/xacro '$(find marimbabot_description)/urdf/marimba_standalone.urdf.xacro'" />
 </launch>

--- a/marimbabot_description/urdf/marimba_standalone.urdf.xacro
+++ b/marimbabot_description/urdf/marimba_standalone.urdf.xacro
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro"
+       name="marimba_standalone" >
+
+  <xacro:include filename="$(find marimbabot_description)/urdf/marimba.urdf.xacro" />
+
+  <link name="world" />
+
+  <joint name="world_marimba_joint" type="fixed">
+    <parent link="world" />
+    <child link = "marimba" />
+    <origin xyz="1.25 0.8 0.9" rpy="0.0 0.0 ${pi}" />
+  </joint>
+
+  <gazebo>
+    <plugin filename="libgazebo_ros_control.so" name="tams_ur5_gazebo_ros_control">
+      <robotNamespace>/marimba</robotNamespace> 
+      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+      <legacyModeNS>true</legacyModeNS>
+      <updateRate>100.0</updateRate>
+    </plugin>
+  </gazebo>
+
+</robot>

--- a/marimbabot_description/urdf/marimbabot_ur5.urdf.xacro
+++ b/marimbabot_description/urdf/marimbabot_ur5.urdf.xacro
@@ -17,8 +17,6 @@
   <xacro:include filename="$(find tams_ur5_description)/urdf/s_model_adapter.urdf.xacro" />
   <xacro:include filename="$(find tams_ur5_description)/urdf/plug_collision_model.urdf.xacro" />
 
-  <xacro:include filename="$(find marimbabot_description)/urdf/marimba.urdf.xacro" />
-
   <xacro:ur5_robot prefix="ur5_" joint_limited="false" xamla_cap="true" />
 
   <!-- ft_adapter -->
@@ -121,11 +119,11 @@
     <origin xyz="0 0 0.003" rpy="0.0 0.0 ${pi/2}" />
   </joint>
 
-  <joint name="world_marimba_joint" type="fixed">
+  <!-- <joint name="world_marimba_joint" type="fixed">
     <parent link="world" />
     <child link = "marimba" />
     <origin xyz="1.25 0.8 0.9" rpy="0.0 0.0 ${pi}" />
-  </joint>
+  </joint> -->
 
   <xacro:if value="$(arg include_mallet)">
     <xacro:include filename="$(find marimbabot_description)/urdf/static_mallet_holder.urdf" />

--- a/marimbabot_description/urdf/static_mallet_holder.urdf
+++ b/marimbabot_description/urdf/static_mallet_holder.urdf
@@ -24,6 +24,16 @@
             </geometry>
         </collision>
     </link>
+    <gazebo reference="mallet_head" >
+        <turnGravityOff>false</turnGravityOff>
+        <selfCollide>true</selfCollide>
+        <!-- TODO material -->
+        <!-- <material>chordophones/OakWood</material> -->
+        <mu1>50.0</mu1>
+        <mu2>50.0</mu2>
+        <kp>1000000.0</kp>
+        <kd>1.0</kd>
+    </gazebo>
 
     <link name="mallet_neck">
         <inertial>
@@ -47,6 +57,16 @@
             </geometry>
         </collision>
     </link>
+    <gazebo reference="mallet_neck" >
+        <turnGravityOff>false</turnGravityOff>
+        <selfCollide>true</selfCollide>
+        <!-- TODO material -->
+        <!-- <material>chordophones/OakWood</material> -->
+        <mu1>50.0</mu1>
+        <mu2>50.0</mu2>
+        <kp>1000000.0</kp>
+        <kd>1.0</kd>
+    </gazebo>
 
     <link name="mallet_base_link">
         <inertial>
@@ -70,6 +90,16 @@
             </geometry>
         </collision>
     </link>
+    <gazebo reference="mallet_base_link" >
+        <turnGravityOff>false</turnGravityOff>
+        <selfCollide>true</selfCollide>
+        <!-- TODO material -->
+        <!-- <material>chordophones/OakWood</material> -->
+        <mu1>50.0</mu1>
+        <mu2>50.0</mu2>
+        <kp>1000000.0</kp>
+        <kd>1.0</kd>
+    </gazebo>
 
     <joint name="group_1_start_link" type="fixed">
         <parent link="mallet_base_link"/>

--- a/marimbabot_hardware/urdf/two_mallet_holder.urdf
+++ b/marimbabot_hardware/urdf/two_mallet_holder.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot name="two_mallet_holder">
-    <link name="mallet_top">
+    <link name="mallet_head">
         <collision>
             <origin xyz="0.0 0.0 0.013625" rpy="0.0 0.0 0.0"/>
             <!-- 0.018375 -->

--- a/marimbabot_ur5_moveit_config/config/marimba_joint_state_controller.yaml
+++ b/marimbabot_ur5_moveit_config/config/marimba_joint_state_controller.yaml
@@ -1,0 +1,7 @@
+# configure gazebo to publish /joint_states for all active joints.
+# fnh: For very fast motions, you might want to increase the rate here...
+#
+marimba/joint_state_controller:
+    type: joint_state_controller/JointStateController
+    publish_rate: 100
+

--- a/marimbabot_ur5_moveit_config/config/marimba_robotmodel.rviz
+++ b/marimbabot_ur5_moveit_config/config/marimba_robotmodel.rviz
@@ -1,0 +1,1184 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /RobotModel1/Links1
+        - /RobotModel2
+      Splitter Ratio: 0.7323529124259949
+    Tree Height: 352
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 0.699999988079071
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        april_tag_ur5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        cable_duct:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        clock:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        floor:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ft_adapter:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ft_fts_robotside:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ft_fts_toolside:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ft_robotiq_ft_frame_id:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        mallet_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        mallet_head:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        mallet_neck:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        map:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        plug_collision_model_link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        plug_collision_model_link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        plug_collision_model_link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_adapter:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_1_link_0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_1_link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_1_link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_1_link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_2_link_0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_2_link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_2_link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_2_link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_middle_link_0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_middle_link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_middle_link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_finger_middle_link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_palm:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        s_model_tool0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        shelf:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        side_wall:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        small_wall:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        tool0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        turtlebot:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        turtlebot_holder:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ur5_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ur5_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ur5_ee_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ur5_forearm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ur5_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ur5_mount_plate:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ur5_shoulder_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ur5_tool0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ur5_upper_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ur5_wrist_1_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ur5_wrist_2_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ur5_wrist_3_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        wall:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Alpha: 1
+      Marker Scale: 0.15000000596046448
+      Name: TF
+      Show Arrows: false
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+    - Acceleration_Scaling_Factor: 1
+      Class: moveit_rviz_plugin/MotionPlanning
+      Enabled: true
+      Move Group Namespace: ""
+      MoveIt_Allow_Approximate_IK: false
+      MoveIt_Allow_External_Program: false
+      MoveIt_Allow_Replanning: false
+      MoveIt_Allow_Sensor_Positioning: false
+      MoveIt_Planning_Attempts: 10
+      MoveIt_Planning_Time: 5
+      MoveIt_Use_Cartesian_Path: false
+      MoveIt_Use_Constraint_Aware_IK: true
+      MoveIt_Workspace:
+        Center:
+          X: 0
+          Y: 0
+          Z: 0
+        Size:
+          X: 2
+          Y: 2
+          Z: 2
+      Name: MotionPlanning
+      Planned Path:
+        Color Enabled: false
+        Interrupt Display: false
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+          april_tag_ur5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          cable_duct:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          clock:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          floor:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ft_adapter:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ft_fts_robotside:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ft_fts_toolside:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ft_robotiq_ft_frame_id:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          mallet_base_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          mallet_head:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          mallet_neck:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          map:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          plug_collision_model_link_1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          plug_collision_model_link_2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          plug_collision_model_link_3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_adapter:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_1_link_0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_1_link_1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_1_link_2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_1_link_3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_2_link_0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_2_link_1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_2_link_2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_2_link_3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_middle_link_0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_middle_link_1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_middle_link_2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_middle_link_3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_palm:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_tool0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          shelf:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          side_wall:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          small_wall:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          tool0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          turtlebot:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          turtlebot_holder:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ur5_base:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ur5_base_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_ee_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_forearm_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_mount:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_mount_plate:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ur5_shoulder_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_tool0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ur5_upper_arm_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_wrist_1_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_wrist_2_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_wrist_3_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wall:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          world:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+        Loop Animation: false
+        Robot Alpha: 0.5
+        Robot Color: 150; 50; 150
+        Show Robot Collision: false
+        Show Robot Visual: true
+        Show Trail: false
+        State Display Time: 3x
+        Trail Step Size: 1
+        Trajectory Topic: move_group/display_planned_path
+        Use Sim Time: false
+      Planning Metrics:
+        Payload: 1
+        Show Joint Torques: false
+        Show Manipulability: false
+        Show Manipulability Index: false
+        Show Weight Limit: false
+        TextHeight: 0.07999999821186066
+      Planning Request:
+        Colliding Link Color: 255; 0; 0
+        Goal State Alpha: 1
+        Goal State Color: 250; 128; 0
+        Interactive Marker Size: 0
+        Joint Violation Color: 255; 0; 255
+        Planning Group: arm
+        Query Goal State: true
+        Query Start State: false
+        Show Workspace: false
+        Start State Alpha: 1
+        Start State Color: 0; 255; 0
+      Planning Scene Topic: move_group/monitored_planning_scene
+      Robot Description: robot_description
+      Scene Geometry:
+        Scene Alpha: 0.8999999761581421
+        Scene Color: 50; 230; 50
+        Scene Display Time: 0.009999999776482582
+        Show Scene Geometry: true
+        Voxel Coloring: Z-Axis
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+          april_tag_ur5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          cable_duct:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          clock:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          floor:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ft_adapter:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ft_fts_robotside:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ft_fts_toolside:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ft_robotiq_ft_frame_id:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          mallet_base_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          mallet_head:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          mallet_neck:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          map:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          plug_collision_model_link_1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          plug_collision_model_link_2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          plug_collision_model_link_3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_adapter:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_1_link_0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_1_link_1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_1_link_2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_1_link_3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_2_link_0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_2_link_1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_2_link_2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_2_link_3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_middle_link_0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_middle_link_1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_middle_link_2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_finger_middle_link_3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_palm:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          s_model_tool0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          shelf:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          side_wall:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          small_wall:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          tool0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          turtlebot:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          turtlebot_holder:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ur5_base:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ur5_base_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_ee_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_forearm_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_mount:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_mount_plate:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ur5_shoulder_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_tool0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          ur5_upper_arm_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_wrist_1_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_wrist_2_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          ur5_wrist_3_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          wall:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          world:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+        Robot Alpha: 1
+        Show Robot Collision: false
+        Show Robot Visual: true
+      Value: true
+      Velocity_Scaling_Factor: 0.9
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        bar_A4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_A5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_A6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_As4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_As5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_As6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_B4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_B5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_B6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_C4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_C5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_C6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_C7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Cs4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Cs5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Cs6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_D4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_D5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_D6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Ds4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Ds5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Ds6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_E4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_E5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_E6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_F4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_F5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_F6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Fs4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Fs5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Fs6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_G4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_G5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_G6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Gs4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Gs5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bar_Gs6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        body_bottom:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        body_left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        body_right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        body_top:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        marimba:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: RobotModel
+      Robot Description: marimba_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+  Enabled: true
+  Global Options:
+    Background Color: 211; 215; 207
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 5.727555274963379
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Field of View: 0.7853981852531433
+      Focal Point:
+        X: 1.0744622945785522
+        Y: 0.5156468749046326
+        Z: 1.007522463798523
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.34039855003356934
+      Target Frame: <Fixed Frame>
+      Yaw: 0.3785586655139923
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1136
+  Hide Left Dock: false
+  Hide Right Dock: true
+  MotionPlanning:
+    collapsed: false
+  MotionPlanning - Trajectory Slider:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001f3000003d2fc020000000bfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000019d000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000280020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006701000001e00000022f0000017d00fffffffb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000001600000016000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000039c0000003efc0100000002fb0000000800540069006d006501000000000000039c000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000001a3000003d200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 924
+  X: 72
+  Y: 27

--- a/marimbabot_ur5_moveit_config/launch/marimbabot_gazebo.launch
+++ b/marimbabot_ur5_moveit_config/launch/marimbabot_gazebo.launch
@@ -12,24 +12,52 @@
   </include>
 
   <!-- send robot urdf to param server, we have some Gazebo modifications here...  -->
-  <include file="$(find marimbabot_description)/launch/marimbabot_ur5_upload.launch" />
+  <include file="$(find marimbabot_description)/launch/load_robot_description.launch" />
+
+  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" 
+   args="-urdf -param robot_description -model robot 
+         -J ur5_shoulder_lift_joint -1.571 -J ur5_shoulder_pan_joint 0.0 -J ur5_elbow_joint 0.0
+         -J ur5_wrist_1_joint -1.571 -J ur5_wrist_2_joint 0.0 -J ur5_wrist_3_joint 0.0" 
+   respawn="false" output="screen" />
 
   <!-- spawn robot in gazebo with start position "home" (=upright) -->
-  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" 
-        args="-urdf -param robot_description -model robot 
-               -J ur5_shoulder_lift_joint -1.571 -J ur5_shoulder_pan_joint 0.0 -J ur5_elbow_joint 0.0
-               -J ur5_wrist_1_joint -1.571 -J ur5_wrist_2_joint 0.0 -J ur5_wrist_3_joint 0.0" 
-        respawn="false" output="screen" />
+  <group ns="marimba">
+      
+      <!-- spawn marimba -->
+      <node name="spawn_gazebo_marimba" pkg="gazebo_ros" type="spawn_model" 
+            args="-urdf -param /marimba_description -model marimba" 
+            respawn="false" output="screen" />
 
+     <node pkg="robot_state_publisher" type="robot_state_publisher" name="marimba_state_publisher">
+      <param name="publish_frequency" type="double" value="100.0" />
+      <param name="tf_prefix" type="string" value="" />
+      <remap from="robot_description" to="marimba_description"/>
+     </node>
+
+    <node pkg="tf" type="static_transform_publisher" name="marimba" args="1.25 0.8 0.9 3.1415 0 0 world marimba 10"/>
+
+  </group>
+
+
+  <!-- ur5 joint controller -->
   <rosparam file="$(find marimbabot_ur5_moveit_config)/config/joint_state_controller.yaml" command="load"/>
   
   <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" 
         args="joint_state_controller" respawn="false" output="screen"/>
 
+  <!-- marimba joint controller -->
+  <rosparam file="$(find marimbabot_ur5_moveit_config)/config/marimba_joint_state_controller.yaml" command="load"/>
+  
+  <node name="marimba_joint_state_controller_spawner" pkg="controller_manager" type="spawner" 
+        args="marimba/joint_state_controller" respawn="false" output="screen"/>
+
+
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="100.0" />
     <param name="tf_prefix" type="string" value="" />
   </node>
+
+
 
   <!-- arm controller, actually called "/pos_joint_traj_controller" -->
   <rosparam file="$(find marimbabot_ur5_moveit_config)/config/arm_controller_ur5.yaml" command="load"/>
@@ -58,6 +86,6 @@
 
   <group if="$(arg launch_rviz)">
    <node name="rviz" pkg="rviz" type="rviz" respawn="false"
-         args="-d $(find tams_ur5_gazebo)/config/tams_ur5_gazebo.rviz"  />
+         args="-d $(find marimbabot_ur5_moveit_config)/config/marimba_robotmodel.rviz"  />
   </group>
 </launch>

--- a/marimbabot_ur5_moveit_config/launch/move_group.launch
+++ b/marimbabot_ur5_moveit_config/launch/move_group.launch
@@ -25,21 +25,6 @@
 
   <arg name="capabilities" default=""/>
   <arg name="disable_capabilities" default=""/>
-  <!-- load these non-default MoveGroup capabilities (space seperated) -->
-  <!--
-  <arg name="capabilities" value="
-                a_package/AwsomeMotionPlanningCapability
-                another_package/GraspPlanningPipeline
-                " />
-  -->
-
-  <!-- inhibit these default MoveGroup capabilities (space seperated) -->
-  <!--
-  <arg name="disable_capabilities" value="
-                move_group/MoveGroupKinematicsService
-                move_group/ClearOctomapService
-                " />
-  -->
 
   <arg name="load_robot_description" default="false" />
   <!-- load URDF, SRDF -->
@@ -102,8 +87,4 @@
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
   </node>
 
-  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
-    <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
-  </include>
-  <node name="moveit_ros_warehouse_services" pkg="moveit_ros_warehouse" type="moveit_warehouse_services" />
 </launch>


### PR DESCRIPTION
Allows to check for collisions between the arm + mallet and marimba. When they are loaded as part of the same URDF (as we did before), they are parts of the same object and their collisions are ignored if `selfCollide` field is `false`. An alternative solution would be #121.
Closes #123 