### PR TITLE
add chords to planning dummy client

### DIFF
--- a/marimbabot_planning/scripts/dummy_client.py
+++ b/marimbabot_planning/scripts/dummy_client.py
@@ -64,11 +64,11 @@ class DummyMotionClient:
             # send goal to server
             self.client.send_goal(goal)
             self.client.wait_for_result()
-            notes_or_accords = self.client.get_result()
-            if notes_or_accords.success:
+            result = self.client.get_result()
+            if result.success:
                 print("Success!")
             else:
-                print(f"Failure: {['None', 'PLANNING_FAILED', 'EXECUTION_FAILED'][notes_or_accords.error_code]}")
+                print(f"Failure: {['None', 'PLANNING_FAILED', 'EXECUTION_FAILED'][result.error_code]}")
 
 if __name__ == '__main__':
     rospy.init_node('dummy_motion_client', anonymous=True)

--- a/marimbabot_planning/scripts/dummy_client.py
+++ b/marimbabot_planning/scripts/dummy_client.py
@@ -44,8 +44,8 @@ class DummyMotionClient:
                 if note.startswith('<') and note.endswith('>'):
                     # Handle chord
                     chord_notes = note[1:-1].split(',')
+                    start_time += duration
                     for chord_note in chord_notes:
-                        start_time += duration
                         goal.hit_sequence_elements.append(
                             HitSequenceElement(
                                 tone_name=chord_note.strip().lower().replace('#', 'is'),
@@ -62,14 +62,12 @@ class DummyMotionClient:
                         octave=octave,
                         loudness=1.0,
                         start_time=start_time))
-                    
             # send goal to server
             self.client.send_goal(goal)
             self.client.wait_for_result()
             result = self.client.get_result()
             if result.success:
                 print("Success!")
-                print(result.executed_sequence_elements)
             else:
                 print(f"Failure: {['None', 'PLANNING_FAILED', 'EXECUTION_FAILED'][result.error_code]}")
 

--- a/marimbabot_planning/scripts/dummy_client.py
+++ b/marimbabot_planning/scripts/dummy_client.py
@@ -35,7 +35,7 @@ class DummyMotionClient:
             # create regex for splitting the notes including only the notes from the scale (C, D, E, F, G, A, B)
             # e.g. 'C, <C#, D>, C#, A' => ['C', '<C#, D>', 'C#', 'A']
             # LIMITED TO A CHORD OF 2 NOTES !!!
-            regex_pattern = r'([CDEFGAB][#b]?|[<].*?[>])'
+            regex_pattern = r'([CDEFGAB][#b]?|[<][CDEFGAB][#b]?,\s?[CDEFGAB][#b]?[>])'
             notes_or_accords = re.findall(regex_pattern, input_str)
 
             # iterate over the notes and send them to the server

--- a/marimbabot_planning/scripts/dummy_client.py
+++ b/marimbabot_planning/scripts/dummy_client.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """
 A dummy action client to call the motions action server.
+Usage:
+Run the dummy client with `rosrun marimbabot_planning dummy_client.py`.
 """
 
 import re
@@ -67,6 +69,7 @@ class DummyMotionClient:
             result = self.client.get_result()
             if result.success:
                 print("Success!")
+                print(result.executed_sequence_elements)
             else:
                 print(f"Failure: {['None', 'PLANNING_FAILED', 'EXECUTION_FAILED'][result.error_code]}")
 


### PR DESCRIPTION
Add regex for splitting the notes including only the notes from the scale (C, D, E, F, G, A, B)

 e.g. 'C, <C#, D>, C#, A' => ['C', '<C#, D>', 'C#', 'A']

Updating the dummy client from @Flova 