### PR TITLE
Use the flex double mallet in simulation

### DIFF
--- a/marimbabot_description/launch/marimbabot_ur5_upload.launch
+++ b/marimbabot_description/launch/marimbabot_ur5_upload.launch
@@ -8,7 +8,7 @@
   -->
   <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" />
 
-  <arg name="mallet_holder_type" default="double_flex" doc="Type of mallet holder: static, flex or flex_double" />
+  <arg name="mallet_holder_type" default="flex_double" doc="Type of mallet holder: static, flex or flex_double" />
 
   <arg name="bars_fixed_joint" default="true" doc="Whether to use prismatic or fixed joints for marimba bars. Set to true for real robot and false for gazebo simulation" />
 

--- a/marimbabot_hardware/launch/mallet_servo_control_debug_dummy.launch
+++ b/marimbabot_hardware/launch/mallet_servo_control_debug_dummy.launch
@@ -4,8 +4,8 @@
         <rosparam file="$(find marimbabot_hardware)/config/joint_limits.yaml" command="load"/>
         
         <!-- ! This is only for demo setups START -->
-        <param name="robot_description" command="cat $(find marimbabot_hardware)/urdf/two_mallet_holder.urdf"/>
-        <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+        <!-- <param name="robot_description" command="cat $(find marimbabot_hardware)/urdf/two_mallet_holder.urdf"/>
+        <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/> -->
         <!-- ! This is only for demo setups END -->
 
         <node name="mallet_hardware_control_node" pkg="marimbabot_hardware" type="mallet_hardware_control_node_dummy" output="screen" />

--- a/marimbabot_simulation/launch/marimbabot_gazebo.launch
+++ b/marimbabot_simulation/launch/marimbabot_gazebo.launch
@@ -23,7 +23,7 @@
                -J ur5_wrist_1_joint -1.571 -J ur5_wrist_2_joint 0.0 -J ur5_wrist_3_joint 0.0" 
         respawn="false" output="screen" />
 
-  <rosparam file="$(find marimbabot_ur5_moveit_config)/config/joint_state_controller.yaml" command="load"/>
+  <rosparam file="$(find marimbabot_ur5_flex_double_moveit_config)/config/joint_state_controller.yaml" command="load"/>
   
   <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" 
         args="joint_state_controller" respawn="false" output="screen"/>
@@ -34,7 +34,7 @@
   </node>
 
   <!-- arm controller, actually called "/pos_joint_traj_controller" -->
-  <rosparam file="$(find marimbabot_ur5_moveit_config)/config/arm_controller_ur5.yaml" command="load"/>
+  <rosparam file="$(find marimbabot_ur5_flex_double_moveit_config)/config/arm_controller_ur5.yaml" command="load"/>
 
   <node name="arm_controller_spawner" pkg="controller_manager" type="spawner" 
         args="pos_joint_traj_controller" respawn="false" output="screen" />
@@ -43,7 +43,7 @@
   <remap from="/follow_joint_trajectory" to="/arm_controller/follow_joint_trajectory"/>
 
   <!-- our Robotiq gripper simulation has all joints actively controlled -->
-  <rosparam file="$(find marimbabot_ur5_moveit_config)/config/gripper_controller.yaml" command="load"/>
+  <rosparam file="$(find marimbabot_ur5_flex_double_moveit_config)/config/gripper_controller.yaml" command="load"/>
 
   <node name="gripper_controller_spawner" pkg="controller_manager" type="spawner" 
         args="gripper_controller" respawn="false" output="screen" />
@@ -56,7 +56,11 @@
         args="pub /calibrated std_msgs/Bool true" />
 
   <!-- Moveit, same configuration as real TAMS robot -->
-  <include file="$(find marimbabot_ur5_moveit_config)/launch/move_group.launch"/>
+  <include file="$(find marimbabot_ur5_flex_double_moveit_config)/launch/move_group.launch"/>
+
+  <!-- Launch finger mallet faker -->
+  <node name="joint_state_mallet_finger" pkg="marimbabot_hardware" type="joint_state.py" output="screen"/>
+  <include file="$(find marimbabot_hardware)/launch/mallet_servo_control_debug_dummy.launch"/>
 
   <group if="$(arg launch_rviz)">
    <node name="rviz" pkg="rviz" type="rviz" respawn="false"

--- a/marimbabot_ur5_flex_double_moveit_config/config/arm_controller_ur5.yaml
+++ b/marimbabot_ur5_flex_double_moveit_config/config/arm_controller_ur5.yaml
@@ -1,0 +1,28 @@
+pos_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
+  joints:
+     - ur5_shoulder_pan_joint
+     - ur5_shoulder_lift_joint
+     - ur5_elbow_joint
+     - ur5_wrist_1_joint
+     - ur5_wrist_2_joint
+     - ur5_wrist_3_joint
+  gains:
+    ur5_shoulder_pan_joint: {p:  1000.0, d: 50.0, i: 100, i_clamp: 40.0}
+    ur5_shoulder_lift_joint: {p: 1000.0, d: 50.0, i: 100, i_clamp: 10.0}
+    ur5_elbow_joint: {p: 1000.0, d: 50, i: 100, i_clamp: 10.0}
+    ur5_wrist_1_joint: {p: 1500.0, d: 50.0, i: 30, i_clamp: 8.0}
+    ur5_wrist_2_joint: {p: 1500.0, d: 20.0, i: 30, i_clamp: 8.0}
+    ur5_wrist_3_joint: {p: 1200.0, d: 20.0, i: 30, i_clamp: 8.0}
+  constraints:
+    goal_time: 0.6
+    stopped_velocity_tolerance: 0.05
+    ur5_shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
+    ur5_shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
+    ur5_elbow_joint: {trajectory: 0.1, goal: 0.1}
+    ur5_wrist_1_joint: {trajectory: 0.1, goal: 0.1}
+    ur5_wrist_2_joint: {trajectory: 0.1, goal: 0.1}
+    ur5_wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+  stop_trajectory_duration: 0.5
+  state_publish_rate:  100
+  action_monitor_rate: 20

--- a/marimbabot_ur5_flex_double_moveit_config/config/gripper_controller.yaml
+++ b/marimbabot_ur5_flex_double_moveit_config/config/gripper_controller.yaml
@@ -1,0 +1,56 @@
+# fake "all-joints-active" JointTrajectoryController for Gazebo simulation
+# of the Robotiq 3-finger hand.
+#
+# gripper_controller:
+  #type: effort_controllers/GripperActionController
+  # type: position_controllers/GripperActionController
+  # joint: s_model_finger_1_joint_1
+
+# it would be more standard to call this "gripper_controller", but for
+# historical reason the thing has been called "gripper_action" in the
+# TAMS UR5 setup moveit config.
+#
+# gripper_controller:
+gripper_controller:
+  type: effort_controllers/JointTrajectoryController
+  # action_ns: ""
+  joints:
+    - s_model_finger_1_joint_1
+    - s_model_finger_1_joint_2
+    - s_model_finger_1_joint_3
+    - s_model_finger_2_joint_1
+    - s_model_finger_2_joint_2
+    - s_model_finger_2_joint_3 
+    - s_model_finger_middle_joint_1
+    - s_model_finger_middle_joint_2
+    - s_model_finger_middle_joint_3
+    - s_model_palm_finger_1_joint
+    - s_model_palm_finger_2_joint
+  gains:
+    s_model_finger_1_joint_1:      { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_finger_1_joint_2:      { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_finger_1_joint_3:      { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_finger_2_joint_1:      { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_finger_2_joint_2:      { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_finger_2_joint_3:      { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_finger_middle_joint_1: { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_finger_middle_joint_2: { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_finger_middle_joint_3: { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_palm_finger_1_joint:   { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+    s_model_palm_finger_2_joint:   { p: 100.0, d:  0.0, i: 10.0, i_clamp: 20.0 }
+  constraints:
+    goal_time: 0.6
+    stopped_velocity_tolerance: 0.05
+    s_model_finger_1_joint_1: {trajectory: 0.1, goal: 0.01}
+    s_model_finger_1_joint_2: {trajectory: 0.1, goal: 0.01}
+    s_model_finger_1_joint_3: {trajectory: 0.1, goal: 0.01}
+    s_model_finger_2_joint_1: {trajectory: 0.1, goal: 0.01}
+    s_model_finger_2_joint_2: {trajectory: 0.1, goal: 0.01}
+    s_model_finger_2_joint_3: {trajectory: 0.1, goal: 0.01}
+    s_model_finger_middle_joint_1: {trajectory: 0.1, goal: 0.01}
+    s_model_finger_middle_joint_2: {trajectory: 0.1, goal: 0.01}
+    s_model_finger_middle_joint_3: {trajectory: 0.1, goal: 0.01}
+  stop_trajctory_duration: 0.5
+  state_publish_rate: 100
+  action_monitor_rate: 20
+

--- a/marimbabot_ur5_flex_double_moveit_config/config/joint_state_controller.yaml
+++ b/marimbabot_ur5_flex_double_moveit_config/config/joint_state_controller.yaml
@@ -1,0 +1,7 @@
+# configure gazebo to publish /joint_states for all active joints.
+# fnh: For very fast motions, you might want to increase the rate here...
+#
+joint_state_controller:
+    type: joint_state_controller/JointStateController
+    publish_rate: 100
+

--- a/marimbabot_ur5_flex_double_moveit_config/launch/chomp_planning_pipeline.launch.xml
+++ b/marimbabot_ur5_flex_double_moveit_config/launch/chomp_planning_pipeline.launch.xml
@@ -3,7 +3,7 @@
   <arg name="jiggle_fraction" default="0.05" />
   <!-- The request adapters (plugins) used when planning. ORDER MATTERS! -->
   <arg name="planning_adapters"
-       default="default_planner_request_adapters/LimitMaxCartesianLinkSpeed
+       default="
                 default_planner_request_adapters/AddTimeParameterization
                 default_planner_request_adapters/ResolveConstraintFrames
                 default_planner_request_adapters/FixWorkspaceBounds

--- a/marimbabot_ur5_flex_double_moveit_config/launch/ompl-chomp_planning_pipeline.launch.xml
+++ b/marimbabot_ur5_flex_double_moveit_config/launch/ompl-chomp_planning_pipeline.launch.xml
@@ -2,7 +2,7 @@
   <!-- load OMPL planning pipeline, but add the CHOMP planning adapter. -->
   <include file="$(find marimbabot_ur5_flex_double_moveit_config)/launch/ompl_planning_pipeline.launch.xml">
     <arg name="planning_adapters"
-         default="default_planner_request_adapters/LimitMaxCartesianLinkSpeed
+         default="
                   default_planner_request_adapters/AddTimeParameterization
                   default_planner_request_adapters/FixWorkspaceBounds
                   default_planner_request_adapters/FixStartStateBounds

--- a/marimbabot_ur5_flex_double_moveit_config/launch/ompl_planning_pipeline.launch.xml
+++ b/marimbabot_ur5_flex_double_moveit_config/launch/ompl_planning_pipeline.launch.xml
@@ -2,7 +2,7 @@
 
   <!-- The request adapters (plugins) used when planning with OMPL. ORDER MATTERS! -->
   <arg name="planning_adapters"
-       default="default_planner_request_adapters/LimitMaxCartesianLinkSpeed
+       default="
                 default_planner_request_adapters/AddTimeParameterization
                 default_planner_request_adapters/ResolveConstraintFrames
                 default_planner_request_adapters/FixWorkspaceBounds

--- a/marimbabot_ur5_flex_double_moveit_config/launch/stomp_planning_pipeline.launch.xml
+++ b/marimbabot_ur5_flex_double_moveit_config/launch/stomp_planning_pipeline.launch.xml
@@ -6,7 +6,7 @@
   <arg name="jiggle_fraction" value="0.05" />
   <!-- The request adapters (plugins) used when planning. ORDER MATTERS! -->
   <arg name="planning_adapters"
-       default="default_planner_request_adapters/LimitMaxCartesianLinkSpeed
+       default="
                 default_planner_request_adapters/AddTimeParameterization
                 default_planner_request_adapters/FixWorkspaceBounds
                 default_planner_request_adapters/FixStartStateBounds


### PR DESCRIPTION
Switch the mallet holder type to `flex_double` in simulation and make appropriate changes, namely:
- Add controllers to double mallet moveit config (copied as-is from old moveit config)
- Switch to double mallet moveit config (i.e. use launch files from the new config)
- Remove LimitMaxCartesianLinkSpeed (not needed, its non-existence was causing an error)

Closes #227