### PR TITLE
237 behavior node dummy client for send plan to motion planning

### DIFF
--- a/marimbabot_behavior/launch/dummy_marimbabot_behavior.launch
+++ b/marimbabot_behavior/launch/dummy_marimbabot_behavior.launch
@@ -1,0 +1,10 @@
+<!-- 
+    This launch file starts everything that is needed, so /scripts/behavior_node_dummy.py can be tested.
+ -->
+
+<launch>
+    <node name="audio_from_lilypond" pkg="marimbabot_audio" type="audio_from_lilypond.py"/>
+    <include file="$(find marimbabot_ur5_flex_double_moveit_config)/launch/demo.launch"/>
+    <include file="$(find marimbabot_planning)/launch/marimbabot.launch"/>
+    <node name="behavior_node" pkg="marimbabot_behavior" type="behavior_node.py" output="screen"/>
+</launch>

--- a/marimbabot_behavior/scripts/behavior_node_dummy.py
+++ b/marimbabot_behavior/scripts/behavior_node_dummy.py
@@ -1,0 +1,26 @@
+# This node is a dummy node that will be used to test the behavior tree
+# It emulates voice commands and publishes to the behavior node
+# It emulates vision information and publishes to the behavior node
+
+import rospy
+from std_msgs.msg import String
+
+
+class DummyBehaviorNode:
+    def __init__(self):
+        self.command_pub = rospy.Publisher('speech_node/command', String, queue_size=10)
+        self.recognized_notes_pub = rospy.Publisher('vision_node/recognized_notes', String, queue_size=10)
+        self.main_loop()
+
+    def main_loop(self):
+        """
+        Wait for keyboard input, concatenate the input into a string, and send it to the server once the user presses enter.
+        """
+        while not rospy.is_shutdown():
+            # get input from user and create goal
+            input_str = input("Enter a command (e.g. 'marimbabot read'): ")
+            recognized_notes_str = input("Enter recognized notes (default 'c4 d4 e4'): ", )
+            recognized_notes_str = recognized_notes_str or 'c4 d4 e4'
+
+            self.command_pub.publish(input_str)
+            self.recognized_notes_pub.publish(recognized_notes_str)

--- a/marimbabot_behavior/scripts/behavior_node_dummy.py
+++ b/marimbabot_behavior/scripts/behavior_node_dummy.py
@@ -8,6 +8,7 @@ from std_msgs.msg import String
 
 class DummyBehaviorNode:
     def __init__(self):
+        rospy.init_node('dummy_behavior_node', anonymous=True)
         self.command_pub = rospy.Publisher('speech_node/command', String, queue_size=10)
         self.recognized_notes_pub = rospy.Publisher('vision_node/recognized_notes', String, queue_size=10)
         self.main_loop()


### PR DESCRIPTION
@yunlong-wang-cn 
As we discussed, here is a dummy node with that you can publish the audio input/commands and the vision input. :+1: 
You should just launch the new launch file and the new node separately.
I still have some bug that the behavior node dies, I try to solve that.
However, you can still give it a try and look whether it works already.
Was I correct that you want to simulate the vision and command inputs?

@scaredycode Do we "need" the other launch file "test_behavior.launch" or was it just for local / one-time-use testing? :) 