### PR TITLE
Command recognition patch ci fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   main_ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -14,26 +14,16 @@ jobs:
           ROS_DISTRO: noetic
           ROS_REPO: main
           AFTER_SETUP_TARGET_WORKSPACE: /root/target_ws/src/marimbabot/load_vcs_workspace.sh
-      - name: Set up Python 3.8.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8.10
-      - name: Install python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi      
-
-  # build_python_requirements:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Set up Python 3.8.10
-  #     uses: actions/setup-python@v4
-  #     with:
-  #       python-version: 3.8.10
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install wheel
-  #       if [ -f requirements.txt ]; then pip install -r requirements.txt; fi        
+  build_python_requirements:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8.10
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+    - name: Install portaudio system dependency
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y portaudio19-dev
     - name: Set up Python 3.8.10
       uses: actions/setup-python@v4
       with:

--- a/marimbabot_speech/package.xml
+++ b/marimbabot_speech/package.xml
@@ -19,11 +19,11 @@
   <build_depend>sound_play</build_depend>
   <build_depend>audio_common_msgs</build_depend>
   <build_depend>portaudio19-dev</build_depend>
-  <!-- <build_depend>libopenblas-dev</build_depend>
+  <build_depend>libopenblas-dev</build_depend>
   <build_depend>cython</build_depend>
   <build_depend>python3-scipy</build_depend>
   <build_depend>libhdf5-dev</build_depend>
-  <build_depend>python3-h5py</build_depend> -->
+  <build_depend>python3-h5py</build_depend>
   <build_depend>python3-precise-runner-pip</build_depend>
 
 
@@ -33,11 +33,11 @@
   <exec_depend>sound_play</exec_depend>
   <exec_depend>audio_common_msgs</exec_depend>
   <exec_depend>portaudio19-dev</exec_depend>
-  <!-- <exec_depend>libopenblas-dev</exec_depend>
+  <exec_depend>libopenblas-dev</exec_depend>
   <exec_depend>cython</exec_depend>
   <exec_depend>python3-scipy</exec_depend>
   <exec_depend>libhdf5-dev</exec_depend>
-  <exec_depend>python3-h5py</exec_depend> -->
+  <exec_depend>python3-h5py</exec_depend>
   <exec_depend>python3-precise-runner-pip</exec_depend>
   
 


### PR DESCRIPTION
Problem:
Python packages depend on system libs that are installed via rosdep.
In the CI, the build & rosdep install job and the installation job are run in parallel.
Because the latter step depends on the first step, in this case, there are two options for me:

1. Run the jobs successively
2. Install the neccessary system dependeny inside the python job

I chose the second one because the first option would result in very long CI times.


@yunlong-wang-cn Please approve and merge this into your branch to fix your problems.