### PR TITLE
add logic for the repeat-parsing issue

### DIFF
--- a/marimbabot_behavior/src/marimbabot_behavior/interpreter.py
+++ b/marimbabot_behavior/src/marimbabot_behavior/interpreter.py
@@ -12,7 +12,7 @@ def create_staff_from_notes(notes):
     # check if file string includes repeat. If yes, remove it as it is added later
     set_repeat = False
     if "\\repeat volta" in notes:
-        print("repeat found")
+        rospy.logdebug("Found a 'repeat volta' in the notes. Removing it as it is added manually.")
         notes = notes.replace("\\repeat volta 2", "")
         set_repeat = True
 

--- a/marimbabot_behavior/src/marimbabot_behavior/interpreter.py
+++ b/marimbabot_behavior/src/marimbabot_behavior/interpreter.py
@@ -1,17 +1,35 @@
-import rospy
-from std_msgs.msg import String
-from marimbabot_msgs.msg import HitSequenceGoal, HitSequenceElement
-
-import tempfile
-from abjad import Block, LilyPondFile, Score, Staff, Voice
-from abjad.persist import as_midi
 import pretty_midi as pm
+import rospy
+from abjad import Block, LilyPondFile, Score, Staff, Voice, Repeat, attach
+from abjad.persist import as_midi
+
+from marimbabot_msgs.msg import HitSequenceElement, HitSequenceGoal
+
+"""
+Creates a Staff from a list of notes
+Also contains the logic for repeats. That is not taken care of by abjad."""
+def create_staff_from_notes(notes):
+    # check if file string includes repeat. If yes, remove it as it is added later
+    set_repeat = False
+    if "\\repeat volta" in notes:
+        print("repeat found")
+        notes = notes.replace("\\repeat volta 2", "")
+        set_repeat = True
+
+    voice_1 = Voice(notes, name="Voice_1")
+    if set_repeat:
+        repeat = Repeat()
+        attach(repeat, voice_1)
+
+    staff = Staff([voice_1], name="Staff_1")
+
+    return staff
+
 
 # create lilypond file from sentence
 def create_lilypond_file(notes):
     # generate abjad staff
-    voice = Voice(notes)
-    staff = Staff([voice])
+    staff = create_staff_from_notes(notes)
     score = Score([staff], name="Score")
 
     # generate abjad score block and midi block as described here https://github.com/Abjad/abjad/issues/1352#issuecomment-904852122

--- a/marimbabot_vision/src/visualization_node.py
+++ b/marimbabot_vision/src/visualization_node.py
@@ -5,20 +5,41 @@ import tempfile
 
 import cv2
 import rospy
-from abjad import Block, LilyPondFile, Staff, Voice
+from abjad import Block, LilyPondFile, Staff, Voice, Repeat, attach
 from abjad.persist import as_png
 from cv_bridge import CvBridge
 from sensor_msgs.msg import Image as ROSImage
 from std_msgs.msg import String
 
+"""
+Duplicate Method as in marimbabot_behavior/interpreter.
+
+Creates a Staff from a list of notes
+Also contains the logic for repeats. That is not taken care of by abjad.
+"""
+def create_staff_from_notes(notes):
+    # check if file string includes repeat. If yes, remove it as it is added later
+    set_repeat = False
+    if "\\repeat volta" in notes:
+        rospy.logdebug("Found a 'repeat volta' in the notes. Removing it as it is added manually.")
+        notes = notes.replace("\\repeat volta 2", "")
+        set_repeat = True
+
+    voice_1 = Voice(notes, name="Voice_1")
+    if set_repeat:
+        repeat = Repeat()
+        attach(repeat, voice_1)
+
+    staff = Staff([voice_1], name="Staff_1")
+
+    return staff
 
 def callback_vision_results(notes, args):
     rospy.logdebug(f"Received notes: {notes.data}")
     pub = args
 
     # generate abjad staff
-    voice = Voice(notes.data)
-    staff = Staff([voice])
+    staff = create_staff_from_notes(notes.data)
 
     # generate lilypond file
     header_block = Block(name="header")


### PR DESCRIPTION
I added a function to do that. 
That should be enough, right?

For testing I used the input string:
`r"\repeat volta 2 \key a \minor e'8 g'8 b'8 <e'' b''>8 ds'2 e'8 <d'' bs''>8 f'8 b'8 c''4 a'8 g'8 f'1"`


I also removed unused code/imports