### PR TITLE
 Adjust Timing information that is returned by planning

### DIFF
--- a/marimbabot_behavior/src/marimbabot_behavior/behavior_node.py
+++ b/marimbabot_behavior/src/marimbabot_behavior/behavior_node.py
@@ -10,7 +10,8 @@ from std_msgs.msg import String
 
 from marimbabot_behavior.interpreter import read_notes
 from marimbabot_msgs.msg import (Command, HitSequence, HitSequenceAction,
-                                 LilypondAudioAction, LilypondAudioGoal)
+                                 HitSequenceElement, LilypondAudioAction,
+                                 LilypondAudioGoal)
 
 
 class ActionDecider:
@@ -171,13 +172,35 @@ class ActionDecider:
     """
     def planning_feedback_cb(self, feedback_msg):
         rospy.logdebug(f"Feedback from planning action server: {feedback_msg}")
-        # send it to audio '/audio/hit_sequence' topic
+        # the feedback message is a ROS Time value that contain the absolute time when the first note of the sequence was hit
+        # Calculate the relative time for each note in order create a HitSequence message
+        absolute_start_time: rospy.Time = feedback_msg.first_note_hit_time
         hit_sequence_msg = HitSequence()
         hit_sequence_msg.header.stamp = rospy.Time.now()
         hit_sequence_msg.sequence_id = self.sequence_id_counter
-        hit_sequence_msg.hit_sequence_elements = feedback_msg
+        
+        # create a list of HitSequenceElement messages
+        hit_sequence_elements : list(HitSequenceElement) = []
 
+        # iterate over the notes in the self.hit_sequence and create a HitSequenceElement message for each note
+        for elem in self.hit_sequence.notes:
+            hit_sequence_element = HitSequenceElement()
+            hit_sequence_element.tone_name = elem.tone_name
+            hit_sequence_element.octave = elem.octave
+            # add the relative start time to the absolute start time
+            hit_sequence_element.start_time = absolute_start_time + rospy.Duration(elem.start_time)
+            hit_sequence_element.tone_duration = elem.tone_duration
+            hit_sequence_element.loudness = elem.loudness
+
+            hit_sequence_elements.append(hit_sequence_element)
+
+        # add the list of HitSequenceElement messages to the HitSequence message
+        hit_sequence_msg.hit_sequence_elements = hit_sequence_elements
+
+        # increment the sequence_id counter
         self.sequence_id_counter += 1
+
+        # send it to audio '/audio/hit_sequence' topic
         self.hit_sequence_pub.publish(hit_sequence_msg)
         
     # communicates with the planning action server to play the hit sequence on the marimba

--- a/marimbabot_msgs/action/HitSequence.action
+++ b/marimbabot_msgs/action/HitSequence.action
@@ -4,7 +4,6 @@ marimbabot_msgs/HitSequenceElement[] hit_sequence_elements # HitSequenceElement 
 #result definition
 ---
 bool success # whether the goal was successfully achieved
-marimbabot_msgs/HitSequenceElement[] executed_sequence_elements # The sequence of HitSequenceElements that was executed, with absolute expected/planned start_time.
 
 # Define the error codes
 uint16 SUCCESS = 0
@@ -16,4 +15,4 @@ uint16 error_code # error code in case of failure (see above)
 #feedback
 ---
 bool playing # whether marimbabot is currently (still) playing, i.e. the goal is still active
-marimbabot_msgs/HitSequenceElement[] executed_sequence_elements # see above
+time first_note_hit_time  # the absolute time when the first note of the sequence was hit

--- a/marimbabot_planning/include/marimbabot_planning/planning.h
+++ b/marimbabot_planning/include/marimbabot_planning/planning.h
@@ -17,7 +17,6 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <trajectory_msgs/JointTrajectoryPoint.h>
-#include <tuple>
 
 namespace marimbabot_planning
 {
@@ -72,7 +71,7 @@ class Planning
          * @return ros::Duration
         **/
 
-        std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> hit_note(
+        std::pair<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> hit_note(
             const moveit_msgs::RobotState& start_state,
             CartesianHitSequenceElement note);
 
@@ -85,7 +84,7 @@ class Planning
          * @return moveit::planning_interface::MoveGroupInterface::Plan
          * @return ros::Duration
         **/
-        std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> hit_notes(
+        std::pair<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> hit_notes(
             const moveit_msgs::RobotState& start_state,
             std::vector<CartesianHitSequenceElement> notes);
 

--- a/marimbabot_planning/include/marimbabot_planning/planning.h
+++ b/marimbabot_planning/include/marimbabot_planning/planning.h
@@ -69,10 +69,10 @@ class Planning
          * @param start_state
          * @param note
          * @return moveit::planning_interface::MoveGroupInterface::Plan
-         * @return ros::Time
+         * @return ros::Duration
         **/
 
-        std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Time> hit_note(
+        std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> hit_note(
             const moveit_msgs::RobotState& start_state,
             CartesianHitSequenceElement note);
 
@@ -83,9 +83,9 @@ class Planning
          * @param start_state
          * @param notes
          * @return moveit::planning_interface::MoveGroupInterface::Plan
-         * @return ros::Time
+         * @return ros::Duration
         **/
-        std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Time> hit_notes(
+        std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> hit_notes(
             const moveit_msgs::RobotState& start_state,
             std::vector<CartesianHitSequenceElement> notes);
 

--- a/marimbabot_planning/include/marimbabot_planning/planning.h
+++ b/marimbabot_planning/include/marimbabot_planning/planning.h
@@ -69,9 +69,10 @@ class Planning
          * @param start_state
          * @param note
          * @return moveit::planning_interface::MoveGroupInterface::Plan
+         * @return ros::Time
         **/
 
-        moveit::planning_interface::MoveGroupInterface::Plan hit_note(
+        std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Time> hit_note(
             const moveit_msgs::RobotState& start_state,
             CartesianHitSequenceElement note);
 

--- a/marimbabot_planning/include/marimbabot_planning/planning.h
+++ b/marimbabot_planning/include/marimbabot_planning/planning.h
@@ -41,6 +41,10 @@ class Planning
         // Last action time
         ros::Time last_action_time_;
 
+        // This time is the action feedback
+        // describes the duration from the start of the action to the first note hit
+        ros::Duration approach_time_to_first_note_hit;
+
         /**
          * @brief Move the robot to its idle/home position
          * 

--- a/marimbabot_planning/include/marimbabot_planning/planning.h
+++ b/marimbabot_planning/include/marimbabot_planning/planning.h
@@ -17,6 +17,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <trajectory_msgs/JointTrajectoryPoint.h>
+#include <tuple>
 
 namespace marimbabot_planning
 {
@@ -40,10 +41,6 @@ class Planning
 
         // Last action time
         ros::Time last_action_time_;
-
-        // This time is the action feedback
-        // describes the duration from the start of the action to the first note hit
-        ros::Duration approach_time_to_first_note_hit;
 
         /**
          * @brief Move the robot to its idle/home position
@@ -85,10 +82,12 @@ class Planning
          * @param start_state
          * @param notes
          * @return moveit::planning_interface::MoveGroupInterface::Plan
+         * @return ros::Time
         **/
-        moveit::planning_interface::MoveGroupInterface::Plan hit_notes(
+        std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Time> hit_notes(
             const moveit_msgs::RobotState& start_state,
             std::vector<CartesianHitSequenceElement> notes);
+
 
 
         /**

--- a/marimbabot_planning/src/planning.cpp
+++ b/marimbabot_planning/src/planning.cpp
@@ -188,7 +188,7 @@ moveit::planning_interface::MoveGroupInterface::Plan Planning::plan_to_mallet_po
  * @return ros::Duration
 **/
 
-std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> Planning::hit_note(
+std::pair<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> Planning::hit_note(
     const moveit_msgs::RobotState& start_state,
     CartesianHitSequenceElement note)
 {
@@ -268,7 +268,7 @@ std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> 
  * @return moveit::planning_interface::MoveGroupInterface::Plan
  * @return ros::Duration
 **/
-std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> Planning::hit_notes(
+std::pair<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> Planning::hit_notes(
     const moveit_msgs::RobotState& start_state,
     std::vector<CartesianHitSequenceElement> points)
 {  
@@ -278,10 +278,10 @@ std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> 
     std::vector<ros::Duration> note_hit_times;
 
     // Calculate hit trajectory
-    std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> result = hit_note(start_state, points.front());
-    moveit::planning_interface::MoveGroupInterface::Plan hit_plan = std::get<0>(result);
-    ros::Duration approach_time_to_first_note_hit = std::get<1>(result);
-
+    moveit::planning_interface::MoveGroupInterface::Plan hit_plan;
+    ros::Duration approach_time_to_first_note_hit;
+    std::tie(hit_plan, approach_time_to_first_note_hit) = hit_note(start_state, points.front());
+    
     // Call hit_points recursively for all remaining hit_points
     if(points.size() > 1)
     {
@@ -332,9 +332,9 @@ void Planning::action_server_callback(const marimbabot_msgs::HitSequenceGoalCons
         auto hits_relative_with_chords = apply_chords(hits_relative);
 
         // Define hit plan
-        std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Duration> result =hit_notes(start_state, hits_relative_with_chords);
-        moveit::planning_interface::MoveGroupInterface::Plan hit_plan = std::get<0>(result);
-        ros::Duration approach_time_to_first_note_hit = std::get<1>(result);
+        moveit::planning_interface::MoveGroupInterface::Plan hit_plan;
+        ros::Duration approach_time_to_first_note_hit;
+        std::tie(hit_plan, approach_time_to_first_note_hit) = hit_notes(start_state, hits_relative_with_chords);
 
         // Publish the plan for rviz
         moveit_msgs::DisplayTrajectory display_trajectory;

--- a/marimbabot_planning/src/planning.cpp
+++ b/marimbabot_planning/src/planning.cpp
@@ -273,7 +273,7 @@ std::tuple<moveit::planning_interface::MoveGroupInterface::Plan, ros::Time> Plan
     std::vector<CartesianHitSequenceElement> points)
 {
     // Declare approach_time_to_first_note_hit for the first note
-    ros::Time approach_time_to_first_note_hit = ros::Duration(0.0);;
+    ros::Time approach_time_to_first_note_hit;
     
     // Assert that there is at least one hit_point with an nice error message
     assert(points.size() > 0 && "There must be at least one hit_point");

--- a/marimbabot_planning/src/planning.cpp
+++ b/marimbabot_planning/src/planning.cpp
@@ -309,7 +309,6 @@ void Planning::action_server_callback(const marimbabot_msgs::HitSequenceGoalCons
     // initialize feedback
     marimbabot_msgs::HitSequenceFeedback feedback;
     feedback.playing = true;
-    feedback.executed_sequence_elements.clear();
 
     try {
         // Set the max velocity and acceleration scaling factors
@@ -351,6 +350,7 @@ void Planning::action_server_callback(const marimbabot_msgs::HitSequenceGoalCons
         ros::Time first_note_hit_time = start_time + this->approach_time_to_first_note_hit;
 
         // Publish the feedback
+        feedback.first_note_hit_time = first_note_hit_time;
         action_server_.publishFeedback(feedback);
 
         // Execute the plan
@@ -370,7 +370,6 @@ void Planning::action_server_callback(const marimbabot_msgs::HitSequenceGoalCons
             action_server_.setAborted(result);
         } else {
             marimbabot_msgs::HitSequenceResult result;
-            result.executed_sequence_elements = feedback.executed_sequence_elements;
             result.success = true;
             action_server_.setSucceeded(result);
         }


### PR DESCRIPTION
This branch restructures how the HitSequence message for the audio is generated.
As described in the original issue, this logic now should calculate a ground truth of the desired note sequence based on the absolute time when the first note was hit/played by the robot.

On the side of the audio:
The audio is not affected directly.
It is just important, that it gets this information after the robot executed the action, because of the current logic. Correct me if I am wrong @yunlong-wang-cn 