### PR TITLE
Audio small patch

### DIFF
--- a/marimbabot_audio/launch/audio_feedback.launch
+++ b/marimbabot_audio/launch/audio_feedback.launch
@@ -12,7 +12,10 @@
           <param name="sample_rate" value="44100" />
       </node>
       
-      <node name="onset_detector" pkg="marimbabot_audio" type="onset_detection.py" output="screen" />
+      <node name="onset_detector" pkg="marimbabot_audio" type="onset_detection.py" output="screen">    
+        <param name="~confidence_threshold" value="0.7"/>
+        <param name="~amplitude_ref" value="25"/>
+      </node>
       <node name="seq_eval" pkg="marimbabot_audio" type="sequence_evaluation.py" output="screen" />
 
       <node name="onsetviz" pkg="marimbabot_audio" type="onsets_visualization.py" output="screen" >

--- a/marimbabot_audio/src/onset_detection.py
+++ b/marimbabot_audio/src/onset_detection.py
@@ -127,7 +127,7 @@ class OnsetDetection:
 			confidence threshold for note classification(crepe)
 		"""
 		# For onset detection
-		self.confidence_threshold = rospy.get_param("~confidence_threshold", 0.7)
+		self.confidence_threshold = rospy.get_param("~confidence_threshold")
 		self.amplitude_ref = rospy.get_param("~amplitude_ref", 10.0)
 		self.windows_for_classification = 0.1  # using 0.1 sec data after onset time for note classification
 		# preload model to not block the callback on first message

--- a/marimbabot_audio/src/onset_detection.py
+++ b/marimbabot_audio/src/onset_detection.py
@@ -127,7 +127,8 @@ class OnsetDetection:
 			confidence threshold for note classification(crepe)
 		"""
 		# For onset detection
-		self.confidence_threshold = 0.7  # the threshold for note classification
+		self.confidence_threshold = rospy.get_param("~confidence_threshold", 0.7)
+		self.amplitude_ref = rospy.get_param("~amplitude_ref", 10.0)
 		self.windows_for_classification = 0.1  # using 0.1 sec data after onset time for note classification
 		# preload model to not block the callback on first message
 		# capacities: 'tiny', 'small', 'medium', 'large', 'full'
@@ -262,7 +263,7 @@ class OnsetDetection:
 		cqt = self.cqt()  # cqt ndarrary  (60,173)
 		self.publish_cqt(cqt)
 
-		onset_env_cqt = librosa.onset.onset_strength(sr=self.sr, S=librosa.amplitude_to_db(cqt, ref=np.max)        )
+		onset_env_cqt = librosa.onset.onset_strength(sr=self.sr, S=librosa.amplitude_to_db(cqt, ref=self.amplitude_ref))
 		# detect when the onset(peak) happened within 2 sec cqt with shape (60,173)
 		'''
 		A sample n is selected as an peak if the corresponding x[n] fulfills the following three conditions:

--- a/marimbabot_bringup/launch/marimbabot.launch
+++ b/marimbabot_bringup/launch/marimbabot.launch
@@ -1,7 +1,7 @@
 <launch>
   <include file="$(find marimbabot_vision)/launch/marimbabot.launch"/>
-  <include file="$(find marimbabot_audio)/launch/marimbabot.launch"/>
-  <include file="$(find marimbabot_planning)/launch/marimbabot.launch"/>
   <include file="$(find marimbabot_speech)/launch/marimbabot.launch"/>
   <include file="$(find marimbabot_behavior)/launch/marimbabot.launch"/>
+  <include file="$(find marimbabot_audio)/launch/marimbabot.launch"/>
+  <include file="$(find marimbabot_planning)/launch/marimbabot.launch"/>
 </launch>

--- a/marimbabot_speech/launch/command_recognition.launch
+++ b/marimbabot_speech/launch/command_recognition.launch
@@ -5,7 +5,7 @@
       <!-- Commandline: "arecord -l" will show available input devices, use the card number as
         the first number and the subdevice number as the second in a string
         like plughw:1,0 -->
-      <param name="device" value="plughw:2,0" />
+      <param name="device" value="plughw:3,0" />
       <param name="format" value="wave" />
       <param name="channels" value="1" />
       <param name="depth" value="16" />
@@ -18,10 +18,12 @@
         <param name="trigger_level"  value="3"/>
         <param name="sensitivity"  value="0.5"/>
         <param name="wad_silence_t"  value="1"/>
-        <param name="wad_max_t"  value="20"/>
+        <param name="wad_max_t"  value="5"/>
     </node>
     <node name="speech2text_node" pkg="marimbabot_speech" type="speech2text.py" output="screen"/>
-    <node name="text2command_node" pkg="marimbabot_speech" type="text2command.py" output="screen"/>
+    <node name="text2command_node" pkg="marimbabot_speech" type="text2command.py" output="screen">
+        <param name="no_speech_prob_threshold"  value="0.25"/>
+    </node>
   </group>
 </launch>
 

--- a/marimbabot_speech/src/speech2text.py
+++ b/marimbabot_speech/src/speech2text.py
@@ -60,7 +60,7 @@ class STT:
 
 	def generate_prompt(self):
 		prompt = "Marimbabot is a instrument playing robot arm. You are able to give it several common robot's commands," \
-		         "for example, play in 60 BPM, play louder by 2 step, play in a loop, review faster by 30 bpm ..."
+		         "for example, play in 60 BPM, play louder by 2 step, play in a loop, preview in by 30 bpm and so on. So the detected text is:"
 		return prompt
 
 	def run(self):

--- a/marimbabot_speech/src/text2command.py
+++ b/marimbabot_speech/src/text2command.py
@@ -182,5 +182,4 @@ class CommandExtraction():
 if __name__ == '__main__':
 	rospy.init_node('command_extractor',log_level=rospy.DEBUG)
 	command_extractor = CommandExtraction()
-	examples_test(command_extractor)
 	rospy.spin()

--- a/marimbabot_speech/src/text2command.py
+++ b/marimbabot_speech/src/text2command.py
@@ -70,7 +70,7 @@ class CommandExtraction():
 		]
 		self.command_pub = rospy.Publisher('/speech_node/command', CommandMsg, queue_size=100, tcp_nodelay=True)
 		self.speech_sub = rospy.Subscriber('/speech_node/speech', SpeechMsg, self.speech_callback, queue_size=10, tcp_nodelay=True)
-
+		self.no_speech_prob_threshold = rospy.get_param('~no_speech_prob_threshold', 0.5)
 	def fill_into_command(self, behavior="", action="", parameters=""):
 		if behavior != "":
 			self.template["behavior"] = behavior
@@ -81,8 +81,8 @@ class CommandExtraction():
 
 	def speech_callback(self, req):
 		text = req.text
-		if req.no_speech_prob > 0.5:
-			rospy.logwarn("even no_speech_prob > 0.5, but is passed the wad, something weird happened, ignore this speech")
+		if req.no_speech_prob > self.no_speech_prob_threshold:
+			rospy.logwarn(f"whisper's no_speech_prob > {self.no_speech_prob_threshold}, even is passed the wad tool, so abandon this text: {text}")
 			return
 		command = self.extract(text)
 		rospy.logdebug(f"command extracted: {command}")


### PR DESCRIPTION
1. add one more threshold to filter out the no-speech noise or the background speech noise by the  `no_speech_preb` reported by Whisper.
2. remove the test log
3. add reference value for onset detection, to enhance the detection of music note from right zone of the marimba, also it has the function of the denoise.